### PR TITLE
fix: Don't send message if websocket closed after callback

### DIFF
--- a/utils/deno/websocket.server.ts
+++ b/utils/deno/websocket.server.ts
@@ -27,7 +27,7 @@ export class WebSocketChannel extends EventTarget implements CallbackBasedChanne
     ) {
         for await (const event of websocket) {
             if (signal.signal.aborted || websocket.isClosed) return
-            callback(event).then((x) => x && websocket.send(x as any), this.error)
+            callback(event).then((x) => x && !websocket.isClosed && websocket.send(x as any), this.error)
         }
     }
     private error = (error: any) => {


### PR DESCRIPTION
I just realized the websocket can get closed after the [`callback`](https://github.com/Jack-Works/async-call-rpc/blob/255e7ea0ca75165a902478e18a5991a82197cc9b/utils/deno/websocket.server.ts#L30) is finished, so another check is needed on this line.